### PR TITLE
Fix errors when alert_logic_agent_state != present

### DIFF
--- a/tasks/Debian-absent.yml
+++ b/tasks/Debian-absent.yml
@@ -10,6 +10,7 @@
     name: al-agent
     state: stopped
     enabled: false
+  ignore_errors: "{{ alert_logic_agent_state != 'present' }}"   # This task can generate an error if the package was never installed.
 
 - name: Ensuree the Alert Logic Debian package is uninstalled
   apt:

--- a/tasks/Debian-present.yml
+++ b/tasks/Debian-present.yml
@@ -9,6 +9,7 @@
     name: al-agent
     state: started
     enabled: true
+  ignore_errors: "{{ alert_logic_agent_state != 'present' }}"   # This task can generate an error if the package was never installed.
 
 - name: Configure rsyslog to send data to the Alert Logic agent (auto-claim style)
   copy:


### PR DESCRIPTION
The 'service' task can generate an error if the package was never installed.
