### PR TITLE
Set c5.large as default template for IDS template

### DIFF
--- a/cloudformation/al_security_ids_full.template
+++ b/cloudformation/al_security_ids_full.template
@@ -45,7 +45,7 @@
         "InstanceType": {
             "Description": "Select the instance type to launch IDS security appliances",
             "Type": "String",
-            "Default": "c5.xlarge",
+            "Default": "c5.large",
             "AllowedValues": [
                 "m4.large",
                 "m4.xlarge",


### PR DESCRIPTION
Switch the instances back to large from xlarge because of overages.